### PR TITLE
.gitattributes: Use LF line endings on Zephyr patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.tflite binary
 *.bin binary
+
+# Always use LF line endings on Zephyr patch files
+zephyr/patches/**/*.patch text eol=lf


### PR DESCRIPTION
Not doing so results in errors when applying the patches on Windows, because their hashes won't match due to the different line ending being used.

This situation has been addressed in Zephyr upstream by https://github.com/zephyrproject-rtos/zephyr/pull/95683, but it will still affect zephyr<=v4.2.0